### PR TITLE
Handle empty request case.

### DIFF
--- a/lib/that_language/service/application.rb
+++ b/lib/that_language/service/application.rb
@@ -14,6 +14,7 @@ module ThatLanguage
       end
 
       route :get, :post, '/detect' do
+        return render_json({}) if text.nil? || text.empty?
         render_json({
           language: ThatLanguage::Iso639[detect.language_code], # TODO: detect.language
           language_code: detect.language_code,

--- a/lib/that_language/service/application.rb
+++ b/lib/that_language/service/application.rb
@@ -25,6 +25,7 @@ module ThatLanguage
       end
 
       route :get, :post, '/details' do
+        return nothing_to_render unless text?
         render_json ThatLanguage.details(text)
       end
 

--- a/lib/that_language/service/application.rb
+++ b/lib/that_language/service/application.rb
@@ -6,15 +6,17 @@ module ThatLanguage
   module Service
     class Application < Sinatra::Application
       route :get, :post, '/language' do
+        return nothing_to_render unless text?
         render_json language: ThatLanguage.language(text)
       end
 
       route :get, :post, '/language_code' do
+        return nothing_to_render unless text?
         render_json language_code: ThatLanguage.language_code(text)
       end
 
       route :get, :post, '/detect' do
-        return render_json({}) if text.nil? || text.empty?
+        return nothing_to_render unless text?
         render_json({
           language: ThatLanguage::Iso639[detect.language_code], # TODO: detect.language
           language_code: detect.language_code,
@@ -59,6 +61,14 @@ module ThatLanguage
 
       def text
         params['text']
+      end
+
+      def text?
+        not text.nil? || text.empty?
+      end
+
+      def nothing_to_render
+        render_json({})
       end
     end
   end

--- a/spec/support/that_language_service_spec_helper.rb
+++ b/spec/support/that_language_service_spec_helper.rb
@@ -20,6 +20,8 @@ module ThatLanguageServiceSpecHelper
     def describe_endpoint(endpoint, methods: [:get, :post], &block)
       methods.each do |method|
         describe("#{method.to_s.upcase} #{endpoint}") do
+          let(:response) { last_response }
+          let(:body) { response.body }
 
           before do
             params = payload.nil? ? {} : { text: payload }
@@ -29,7 +31,7 @@ module ThatLanguageServiceSpecHelper
           it { is_expected.to be_ok }
 
           describe "header" do
-            subject(:header) { last_response.header }
+            subject(:header) { response.header }
 
             specify "Content-Type is JSON" do
               expect(header["Content-Type"]).to eq("application/json")
@@ -37,7 +39,7 @@ module ThatLanguageServiceSpecHelper
           end
 
           describe "response as a json" do
-            subject(:json) { JSON.parse(last_response.body) }
+            subject(:json) { JSON.parse(response.body) }
 
             it { is_expected.to be_a(Hash) }
             class_eval(&block)

--- a/spec/support/that_language_service_spec_helper.rb
+++ b/spec/support/that_language_service_spec_helper.rb
@@ -17,9 +17,10 @@ module ThatLanguageServiceSpecHelper
   end
 
   module ClassMethods
-    def describe_endpoint(endpoint, payload: nil, methods: [:get, :post], &block)
+    def describe_endpoint(endpoint, methods: [:get, :post], &block)
       methods.each do |method|
         describe("#{method.to_s.upcase} #{endpoint}") do
+
           before do
             params = payload.nil? ? {} : { text: payload }
             send(method, endpoint, params)

--- a/spec/that_language/service/application_spec.rb
+++ b/spec/that_language/service/application_spec.rb
@@ -5,17 +5,17 @@ require_relative 'empty_response_specs'
 describe ThatLanguage::Service::Application do
   include ThatLanguageServiceSpecHelper
 
-  payload = "Hallo Welt"
+  let(:payload) { "Hallo Welt" }
 
-  describe_endpoint "/language", payload: payload do
+  describe_endpoint "/language" do
     it { is_expected.to include("language" => "German") }
   end
 
-  describe_endpoint "/language_code", payload: payload do
+  describe_endpoint "/language_code" do
     it { is_expected.to include("language_code" => "de") }
   end
 
-  describe_endpoint "/detect", payload: payload do
+  describe_endpoint "/detect" do
     it { is_expected.to include("language" => "German") }
     it { is_expected.to include("language_code" => "de") }
     it { is_expected.to include("confidence" => 0.5) }
@@ -30,7 +30,7 @@ describe ThatLanguage::Service::Application do
     end
   end
 
-  describe_endpoint "/details", payload: payload do
+  describe_endpoint "/details" do
     it { is_expected.to include("results") }
 
     describe "results" do

--- a/spec/that_language/service/application_spec.rb
+++ b/spec/that_language/service/application_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'support/that_language_service_spec_helper'
+require_relative 'empty_response_specs'
 
 describe ThatLanguage::Service::Application do
   include ThatLanguageServiceSpecHelper
@@ -22,6 +23,11 @@ describe ThatLanguage::Service::Application do
     it { is_expected.not_to include("hit_ratio") }
     it { is_expected.not_to include("hit_count") }
     it { is_expected.not_to include("words_count") }
+
+    describe "when empty payload provided" do
+      let(:payload) { "" }
+      it_behaves_like :empty_response
+    end
   end
 
   describe_endpoint "/details", payload: payload do

--- a/spec/that_language/service/application_spec.rb
+++ b/spec/that_language/service/application_spec.rb
@@ -38,6 +38,10 @@ describe ThatLanguage::Service::Application do
   end
 
   describe_endpoint "/details" do
+    it_behaves_like :empty_response do
+      let(:payload) { "" }
+    end
+
     it { is_expected.to include("results") }
 
     describe "results" do

--- a/spec/that_language/service/application_spec.rb
+++ b/spec/that_language/service/application_spec.rb
@@ -9,10 +9,18 @@ describe ThatLanguage::Service::Application do
 
   describe_endpoint "/language" do
     it { is_expected.to include("language" => "German") }
+
+    it_behaves_like :empty_response do
+      let(:payload) { "" }
+    end
   end
 
   describe_endpoint "/language_code" do
     it { is_expected.to include("language_code" => "de") }
+
+    it_behaves_like :empty_response do
+      let(:payload) { "" }
+    end
   end
 
   describe_endpoint "/detect" do
@@ -24,9 +32,8 @@ describe ThatLanguage::Service::Application do
     it { is_expected.not_to include("hit_count") }
     it { is_expected.not_to include("words_count") }
 
-    describe "when empty payload provided" do
+    it_behaves_like :empty_response do
       let(:payload) { "" }
-      it_behaves_like :empty_response
     end
   end
 

--- a/spec/that_language/service/empty_response_specs.rb
+++ b/spec/that_language/service/empty_response_specs.rb
@@ -1,0 +1,5 @@
+shared_examples_for :empty_response do
+  it "responds with empty JSON object" do
+    expect(subject).to eq "{}"
+  end
+end

--- a/spec/that_language/service/empty_response_specs.rb
+++ b/spec/that_language/service/empty_response_specs.rb
@@ -1,5 +1,5 @@
 shared_examples_for :empty_response do
   it "responds with empty JSON object" do
-    expect(subject).to eq "{}"
+    expect(body).to eq "{}"
   end
 end


### PR DESCRIPTION
Hello. 

How should we handle the empty response case?
- Respond with { "error": "no text given" }
- Respond with empty object

Beside that it is needed to make "payload" in specs easily redefined. At the moment it is defined on spec helper and not easily over-writable.
