### PR TITLE
Disable `Rack::Protection::JsonCsrf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.3 [☰](https://github.com/Deradon/that_language-service/compare/v0.1.2...master) (unreleased)
 
+### Bug fixes
+
+* Allow get requests with a referrer from a different domain ([Disable `Rack::Protection::JsonCsrf`](https://github.com/Deradon/that_language-service/pull/2))
+
 ### Enhancements
 
 * All routes listen to post and get requests

--- a/lib/that_language/service/application.rb
+++ b/lib/that_language/service/application.rb
@@ -5,6 +5,8 @@ require "that_language"
 module ThatLanguage
   module Service
     class Application < Sinatra::Application
+      set :protection, except: [:json_csrf]
+
       route :get, :post, '/language' do
         render_json language: ThatLanguage.language(text)
       end
@@ -49,6 +51,7 @@ module ThatLanguage
 
       def render_json(obj)
         content_type :json
+
         obj.to_json
       end
 

--- a/spec/support/that_language_service_spec_helper.rb
+++ b/spec/support/that_language_service_spec_helper.rb
@@ -17,12 +17,12 @@ module ThatLanguageServiceSpecHelper
   end
 
   module ClassMethods
-    def describe_endpoint(endpoint, payload: nil, methods: [:get, :post], &block)
+    def describe_endpoint(endpoint, payload: nil, methods: [:get, :post], rack_env: {}, &block)
       methods.each do |method|
         describe("#{method.to_s.upcase} #{endpoint}") do
           before do
             params = payload.nil? ? {} : { text: payload }
-            send(method, endpoint, params)
+            send(method, endpoint, params, rack_env)
           end
 
           it { is_expected.to be_ok }

--- a/spec/that_language/service/application_spec.rb
+++ b/spec/that_language/service/application_spec.rb
@@ -110,4 +110,10 @@ describe ThatLanguage::Service::Application do
   describe_endpoint "/version" do
     it { is_expected.to include("version" => "0.1.2") }
   end
+
+  context "with a referer" do
+    describe_endpoint "/version", rack_env: { "HTTP_REFERER" => "http://example.com" } do
+      # NOOP (run only the specs included in the `describe_endpoint` macro)
+    end
+  end
 end


### PR DESCRIPTION
By disabling this protection JSON get requests with a referrer from a
different domain are allowed. It is safe to disable this protection as
long as we do not return any session specific data.
## Links
- Stackoverflow: [Sinatra and Rack Protection setting](http://stackoverflow.com/questions/10509774/sinatra-and-rack-protection-setting)
